### PR TITLE
changed bool to int32_t to allow building 

### DIFF
--- a/tests/fam_atomic_multi_node_test.c
+++ b/tests/fam_atomic_multi_node_test.c
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/stat.h>
 #include <time.h>
 
 /*
@@ -204,7 +205,7 @@ struct data {
 struct benchmark_data {
 	int64_t iterations;
 	bool start;
-	bool done;
+	int32_t done;
 };
 
 bool file_exists(char *filename)
@@ -428,4 +429,3 @@ int main(int argc, char **argv)
 
 	return 0;
 }
-


### PR DESCRIPTION
added fam_atomic_multi_node_test.c from libfam-atomic branch upstream. This changes the bool in benchmark_data to int32_t to allow package building. 