### PR TITLE
Fixing an assert

### DIFF
--- a/rcu-rbtree/urcu-bp.c
+++ b/rcu-rbtree/urcu-bp.c
@@ -319,7 +319,7 @@ static void add_thread(void)
 
 	/* Add to registry */
 	rcu_reader_reg->tid = pthread_self();
-	assert(rcu_reader_reg->ctr == 0);
+	rcu_reader_reg->ctr = 0;
 	cds_list_add(&rcu_reader_reg->node, &registry);
 	rcu_reader = rcu_reader_reg;
 }


### PR DESCRIPTION
We were hitting this assert on the new 4.14 kernel. The logic of the
add_thread function is to get an unallocated registry_arena. The ctr
field in the registry_arena should be 0, but we hit the assert.
Set the ctr field to 0 explicitly to initialize the new registry.

Signed-off-by: Betty Dall <betty.dall@hpe.com>